### PR TITLE
Improve experiments registration/fetching API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        //JUnit5 - to be able to: apply plugin: "de.mannodermaus.android-junit5"
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.3.1.1"
-
+        // for com.vanniktech.android.junit.jacoco plugin
         classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.15.0"
     }
 }
@@ -27,6 +25,7 @@ allprojects {
     }
 }
 
+//adds report aggregation tasks such as jacocoTestReport & jacocoTestReport<FLAVOR><BUILD_TYPE>
 apply plugin: "com.vanniktech.android.junit.jacoco"
 
 task clean(type: Delete) {

--- a/cadabra-android/build.gradle
+++ b/cadabra-android/build.gradle
@@ -18,6 +18,15 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+            testLogging {
+                events 'PASSED', 'FAILED', 'SKIPPED'
+            }
+        }
+    }
 }
 
 dependencies {
@@ -27,10 +36,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
-    testImplementation 'junit:junit:4.12'
+    //Kotlintest
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation 'io.kotlintest:kotlintest-runner-junit5:3.3.2'
 
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    //JUnit5 (Required for kotlintest and spek)
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.4.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.4.2"
 }
 
 repositories {

--- a/cadabra-android/src/main/java/com/github/fo2rist/cadabraandroid/CadabraAndroid.kt
+++ b/cadabra-android/src/main/java/com/github/fo2rist/cadabraandroid/CadabraAndroid.kt
@@ -1,8 +1,26 @@
 package com.github.fo2rist.cadabraandroid
 
 import com.github.fo2rist.cadabra.Cadabra
+import com.github.fo2rist.cadabra.CadabraConfig
 
 /**
  * Android-specific cadabra extension that supports resources injection.
  */
-class CadabraAndroid : Cadabra by Cadabra.instance
+interface CadabraAndroid {
+
+    companion object {
+
+        /**
+         * Entry point CadabraAndroid experiment variants usage.
+         */
+        val instance: CadabraAndroid
+            get() = CadabraAndroidImpl
+
+        /**
+         * Entry point for Cadabra configuration.
+         * Same as [Cadabra.config].
+         */
+        val config: CadabraConfig
+            get() = Cadabra.config
+    }
+}

--- a/cadabra-android/src/main/java/com/github/fo2rist/cadabraandroid/CadabraAndroidImpl.kt
+++ b/cadabra-android/src/main/java/com/github/fo2rist/cadabraandroid/CadabraAndroidImpl.kt
@@ -1,0 +1,5 @@
+package com.github.fo2rist.cadabraandroid
+
+import com.github.fo2rist.cadabra.Cadabra
+
+internal object CadabraAndroidImpl : CadabraAndroid, Cadabra by Cadabra.instance

--- a/cadabra-android/src/test/java/com/github/fo2rist/cadabraandroid/CadabraAndroidKotlinTest.kt
+++ b/cadabra-android/src/test/java/com/github/fo2rist/cadabraandroid/CadabraAndroidKotlinTest.kt
@@ -1,0 +1,19 @@
+package com.github.fo2rist.cadabraandroid
+
+import com.github.fo2rist.cadabra.Cadabra
+import io.kotlintest.matchers.types.shouldBeSameInstanceAs
+import io.kotlintest.specs.WordSpec
+
+class CadabraAndroidKotlinTest : WordSpec({
+    "CadabraAndroid.instance" should {
+        "return CadabraAndroidImpl" {
+            CadabraAndroid.instance shouldBeSameInstanceAs CadabraAndroidImpl
+        }
+    }
+
+    "CadabraAndroid.config" should {
+        "return Cadabra.config" {
+            CadabraAndroid.config shouldBeSameInstanceAs Cadabra.config
+        }
+    }
+})

--- a/cadabra-core/build.gradle
+++ b/cadabra-core/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     // spek requires kotlin-reflect, can be omitted if already in the classpath
     testRuntimeOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    //JUnit5 (Required) Writing and executing Unit Tests on the JUnit Platform
+    //JUnit5 (Required for kotlintest and spek)
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.4.2"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.4.2"
 }

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/CadabraImpl.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/CadabraImpl.kt
@@ -1,0 +1,66 @@
+package com.github.fo2rist.cadabra
+
+import kotlin.reflect.KClass
+
+/**
+ * Single internal entry point for experiments registration and access.
+ */
+internal object CadabraImpl : Cadabra, CadabraConfig {
+
+    private val resolversMap: MutableMap<String, Pair<Experiment<*>, Resolver<*>>> = mutableMapOf()
+
+    override fun <E : Experiment<V>, V : Variant> getExperimentVariant(experiment: E): V {
+        return getExperimentVariantById(experiment.id)
+    }
+
+    override fun <V : Variant> getExperimentVariant(variantClass: Class<V>): V {
+        return getExperimentVariantById(variantClass.simpleName)
+    }
+
+
+    override fun <V : Variant> getExperimentVariant(variantClass: KClass<V>): V {
+        return getExperimentVariant(variantClass.java)
+    }
+
+    private fun <V : Variant> getExperimentVariantById(experimentId: ExperimentId): V {
+        val experimentResolverPair = resolversMap[experimentId]
+            ?: throw IllegalStateException("Experiment with ID '$experimentId' is not registered")
+
+        return experimentResolverPair.second.variant as V
+    }
+
+    override fun <E, V> registerExperiment(
+        experiment: E,
+        resolver: Resolver<V>
+    ): CadabraConfig where E : Experiment<V>, V : Variant, V : Enum<V> {
+        check(experiment.id !in resolversMap) { "Experiment already registered: $experiment" }
+
+        resolversMap[experiment.id] = Pair(experiment, resolver)
+        return this
+    }
+
+    override fun <V> registerExperiment(
+        variantsClass: Class<V>,
+        resolver: Resolver<V>
+    ): CadabraConfig where V : Variant, V : Enum<V> {
+        val experiment = object : BaseExperiment<V>(variantsClass) {
+            override val id: ExperimentId = variantsClass.simpleName
+        }
+
+        return registerExperiment(experiment, resolver)
+    }
+
+    override fun <V> registerExperiment(
+        variantsClass: KClass<V>,
+        resolver: Resolver<V>
+    ): CadabraConfig where V : Variant, V : Enum<V> {
+        return registerExperiment(variantsClass.java, resolver)
+    }
+
+    /**
+     * Unregister all experiments.
+     */
+    internal fun reset(){
+        resolversMap.clear()
+    }
+}

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Experiment.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Experiment.kt
@@ -38,13 +38,13 @@ interface Experiment<V>
  * @param V enum that defines all available variants for the experiment.
  */
 abstract class BaseExperiment<V>(
-    variantsEnum: Class<V>
+    variantsClass: Class<V>
 ) : Experiment<V> where V : Variant, V : Enum<V> {
 
-    constructor(variantsEnum: KClass<V>) : this(variantsEnum.java)
+    constructor(variantsClass: KClass<V>) : this(variantsClass.java)
 
     /**
      * All variants from [V].
      */
-    override val variants = variantsEnum.enumConstants.toList()
+    override val variants = variantsClass.enumConstants.toList()
 }

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Resolver.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Resolver.kt
@@ -8,8 +8,9 @@ interface Resolver<V> where V : Variant, V : Enum<V> {
      * Get variant to be used now.
      * Note that Cadabra calls this method every time variant resolution is required, so if the same variant should be
      * provided for particular user/session/etc. make sure either cache it in the app and don't ask twice or
-     * implement receiver in a way it takes care of that. Receiver-side implementation is recommended to keep the
-     * app code free from the experiment-related code.
+     * implement receiver in a way it takes care of that.
+     * It's recommended to keep the app code free from the experiment-related code so caching inside he receiver is
+     * preferred.
      */
     val variant: V
 }

--- a/cadabra-core/src/test/java/com/github/fo2rist/cadabra/CadabraImplKotlinTest.kt
+++ b/cadabra-core/src/test/java/com/github/fo2rist/cadabra/CadabraImplKotlinTest.kt
@@ -1,0 +1,81 @@
+package com.github.fo2rist.cadabra
+
+import com.github.fo2rist.cadabra.testdata.SimpleExperiment
+import com.github.fo2rist.cadabra.testdata.SimpleStaticResolver
+import com.github.fo2rist.cadabra.testdata.SimpleVariants
+import io.kotlintest.TestCase
+import io.kotlintest.matchers.beOfType
+import io.kotlintest.should
+import io.kotlintest.shouldNotThrow
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.WordSpec
+
+private val EXPERIMENT1 = SimpleExperiment()
+private val EXPERIMENT2 = SimpleExperiment()
+
+class CadabraImplKotlinTest : WordSpec({
+    "registerExperiment(Experiment, Resolver)" should {
+        "not register the same experiment twice" {
+            CadabraImpl.registerExperiment(EXPERIMENT1, SimpleStaticResolver())
+
+            shouldThrow<IllegalStateException> {
+                CadabraImpl.registerExperiment(EXPERIMENT1, SimpleStaticResolver())
+            }
+        }
+
+        "not register experiments with the same ID" {
+            CadabraImpl.registerExperiment(EXPERIMENT1, SimpleStaticResolver())
+
+            shouldThrow<IllegalStateException> {
+                CadabraImpl.registerExperiment(EXPERIMENT2, SimpleStaticResolver())
+            }
+        }
+    }
+
+    "registerExperiment(Variant, Resolver)" should {
+        "not register experiments with the same variants" {
+            CadabraImpl.registerExperiment(SimpleVariants::class, SimpleStaticResolver())
+
+            shouldThrow<IllegalStateException> {
+                CadabraImpl.registerExperiment(SimpleVariants::class, SimpleStaticResolver())
+            }
+        }
+
+        "accept Java class as variants" {
+            shouldNotThrow<Exception> {
+                CadabraImpl.registerExperiment(SimpleVariants::class.java, SimpleStaticResolver())
+            }
+        }
+    }
+
+    "getExperimentVariant" should {
+
+        "throw exception when experiment not registered" {
+            shouldThrow<java.lang.IllegalStateException> {
+                CadabraImpl.getExperimentVariant(EXPERIMENT1)
+            }
+        }
+
+        "return variant when experiment registered via Experiment instance" {
+            CadabraImpl.registerExperiment(EXPERIMENT1, SimpleStaticResolver())
+
+            CadabraImpl.getExperimentVariant(EXPERIMENT1) should beOfType<SimpleVariants>()
+        }
+
+        "return variant when experiment registered via Variant class" {
+            CadabraImpl.registerExperiment(SimpleVariants::class, SimpleStaticResolver())
+
+            CadabraImpl.getExperimentVariant(SimpleVariants::class) should beOfType<SimpleVariants>()
+        }
+
+        "return variant when experiment registered via Variant Java class" {
+            CadabraImpl.registerExperiment(SimpleVariants::class.java, SimpleStaticResolver())
+
+            CadabraImpl.getExperimentVariant(SimpleVariants::class.java) should beOfType<SimpleVariants>()
+        }
+    }
+}) {
+    override fun beforeTest(testCase: TestCase) {
+        CadabraImpl.reset()
+    }
+}

--- a/cadabra-core/src/test/java/com/github/fo2rist/cadabra/CadabraKotlinTest.kt
+++ b/cadabra-core/src/test/java/com/github/fo2rist/cadabra/CadabraKotlinTest.kt
@@ -1,61 +1,18 @@
 package com.github.fo2rist.cadabra
 
-import com.github.fo2rist.cadabra.testdata.SimpleExperiment
-import com.github.fo2rist.cadabra.testdata.SimpleStaticResolver
-import com.github.fo2rist.cadabra.testdata.SimpleVariants
-import io.kotlintest.TestCase
-import io.kotlintest.matchers.beOfType
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
+import io.kotlintest.matchers.types.shouldBeSameInstanceAs
 import io.kotlintest.specs.WordSpec
-
-private val EXPERIMENT1 = SimpleExperiment()
-private val EXPERIMENT2 = SimpleExperiment()
 
 class CadabraKotlinTest : WordSpec({
     "Cadabra.instance" should {
-        "returns CadabraImpl" {
-            Cadabra.instance shouldBe CadabraImpl
+        "return CadabraImpl" {
+            Cadabra.instance shouldBeSameInstanceAs CadabraImpl
         }
     }
 
-    "Cadabra.Config" should {
-        "not register the same experiment twice" {
-
-            Cadabra.Config.registerExperiment(EXPERIMENT1, SimpleStaticResolver())
-
-            shouldThrow<IllegalStateException> {
-                Cadabra.Config.registerExperiment(EXPERIMENT1, SimpleStaticResolver())
-            }
-        }
-
-        "not register experiments with the same ID" {
-
-            Cadabra.Config.registerExperiment(EXPERIMENT1, SimpleStaticResolver())
-
-            shouldThrow<IllegalStateException> {
-                Cadabra.Config.registerExperiment(EXPERIMENT2, SimpleStaticResolver())
-            }
+    "Cadabra.config" should {
+        "return CadabraImpl" {
+            Cadabra.config shouldBeSameInstanceAs CadabraImpl
         }
     }
-
-    "Cadabra getExperimentVariant" should {
-        "throw exception when experiment not registered" {
-            shouldThrow<java.lang.IllegalStateException> {
-                Cadabra.instance.getExperimentVariant(EXPERIMENT1)
-            }
-        }
-
-        "return variant when experiment registered" {
-            Cadabra.Config.registerExperiment(EXPERIMENT1, SimpleStaticResolver())
-
-            Cadabra.instance.getExperimentVariant(EXPERIMENT1) should beOfType<SimpleVariants>()
-        }
-
-    }
-}) {
-    override fun beforeTest(testCase: TestCase) {
-        CadabraImpl.reset()
-    }
-}
+})

--- a/sample-android-app/src/main/java/com/github/fo2rist/cadabra/CadabraTestApplication.kt
+++ b/sample-android-app/src/main/java/com/github/fo2rist/cadabra/CadabraTestApplication.kt
@@ -14,7 +14,7 @@ class CadabraTestApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        Cadabra.Config
+        Cadabra.config
             .registerExperiment(
                 GreetingExperiment,
                 RandomResolver(GreetingVariants::class)


### PR DESCRIPTION
Provide Cadabra instance and config as companion properties for consistency for both
Cadabra and CadabraAndroid
Allow registering experiments without Experiment object
Move Cadabra implementation to the separated file

Close https://github.com/fo2rist/cadabra/projects/1#card-22208695