### PR TITLE
Simplify experiments setup

### DIFF
--- a/cadabra-android/src/test/java/com/github/fo2rist/cadabraandroid/CadabraAndroidTest.kt
+++ b/cadabra-android/src/test/java/com/github/fo2rist/cadabraandroid/CadabraAndroidTest.kt
@@ -49,7 +49,7 @@ class CadabraAndroidTest {
     }
 
     @Test
-    fun `getXyz throws exception when default resource is missing`() {
+    fun `get%RESOURCE% throws exception when default resource is missing`() {
         exceptionRule.expect(Resources.NotFoundException::class.java)
         cadabraAndroid.getExperimentContext(SimpleAndroidExperiment::class).getStringId(-1)
 

--- a/cadabra-android/src/test/java/com/github/fo2rist/cadabraandroid/CadabraAndroidTest.kt
+++ b/cadabra-android/src/test/java/com/github/fo2rist/cadabraandroid/CadabraAndroidTest.kt
@@ -2,8 +2,8 @@ package com.github.fo2rist.cadabraandroid
 
 import android.content.res.Resources
 import com.github.fo2rist.cadabraandroid.test.R
-import com.github.fo2rist.cadabraandroid.testdata.SimpleAndroidStaticResolver
 import com.github.fo2rist.cadabraandroid.testdata.SimpleAndroidExperiment
+import com.github.fo2rist.cadabraandroid.testdata.SimpleAndroidStaticResolver
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Cadabra.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Cadabra.kt
@@ -1,8 +1,8 @@
 package com.github.fo2rist.cadabra
 
 import com.github.fo2rist.cadabra.exceptions.ExperimentAlreadyRegistered
-import com.github.fo2rist.cadabra.exceptions.ExperimentNotActive
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotFound
+import com.github.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.github.fo2rist.cadabra.exceptions.UnknownVariant
 import kotlin.reflect.KClass
 
@@ -15,32 +15,32 @@ import kotlin.reflect.KClass
  *  - register and start experiments via [Cadabra.config]
  *  - when it's time to apply experimental parameters get the variant via [Cadabra.instance]'s [getExperimentVariant]
  *
- *  Experiment registration:
- *  When experiment is registered via [CadabraConfig.registerExperiment] it become discoverable by name but inactive.
- *  For inactive experiment [getExperimentVariant] can not be used yet, to activate registered experiments use
- *  [CadabraConfig.activateExperiments]. You can register multiple experiments and then activate as many as needed with
- *  a single [CadabraConfig.activateExperiments] call.
- *  Or use [CadabraConfig.startExperiment] to register and activate experiment at the same time.
+ *  Experiment registration & start:
+ *  When experiment is registered via [CadabraConfig.registerExperiment] it become discoverable by name and waiting
+ *  to be started. For such experiment [getExperimentVariant] can not be used yet.
+ *  To start registered experiments use [CadabraConfig.startExperiments]. You can register multiple experiments and then
+ *  start as many as needed with a single [CadabraConfig.startExperiments] call.
+ *  Or use [CadabraConfig.startExperiment] to register and start experiment at the same time.
  */
 interface Cadabra {
 
     /**
      * Get experiment variant to apply for this user/session by [Variant] class.
-     * Only works if the experiment is registered and active.
+     * Only works if the experiment is started.
      * @see [CadabraConfig.registerExperiment]
      * @see [CadabraConfig.startExperiment]
      * @throws ExperimentNotFound if experiment is not registered
-     * @throws ExperimentNotActive is experiment was not activated
+     * @throws ExperimentNotStarted is experiment was not started
      */
     fun <V : Variant> getExperimentVariant(experiment: KClass<V>): V
 
     /**
      * Get experiment variant to apply for this user/session by [Variant] class.
-     * Only works if the experiment is registered and active.
+     * Only works if the experiment is started.
      * @see [CadabraConfig.registerExperiment]
      * @see [CadabraConfig.startExperiment]
      * @throws ExperimentNotFound if experiment is not registered
-     * @throws ExperimentNotActive is experiment was not activated
+     * @throws ExperimentNotStarted is experiment was not started
      */
     fun <V : Variant> getExperimentVariant(experiment: Class<V>): V
 
@@ -86,24 +86,24 @@ interface CadabraConfig {
     ): CadabraConfig where V : Variant, V : Enum<V>
 
     /**
-     * Activate previously registered experiments.
-     * Experiments previously activated will be reactivated with a new active variant specified.
+     * Start previously registered experiments.
+     * Experiments previously started will be reconfigured with a new active variant specified.
      * Experiments with unknown IDs will be ignored.
      * @throws UnknownVariant if provided variant doesn't match registered experiment
      */
-    fun activateExperiments(config: ExperimentsConfig)
+    fun startExperiments(config: ExperimentsConfig)
 
     /**
-     * Activate previously registered experiment asynchronously.
+     * Start previously registered experiment asynchronously.
      * Registers the [ExperimentsConfigProvider] that can update experiments config at any time.
      * When it provides the new config via [provideConfig][ExperimentsConfigProvider.provideConfig] it works the same
-     * way as [activateExperiments].
+     * way as [startExperiments].
      */
-    fun activateExperimentsAsync(configProvider: ExperimentsConfigProvider)
+    fun startExperimentsAsync(configProvider: ExperimentsConfigProvider)
 
     /**
      * Register & start experiment.
-     * A combination of [registerExperiment] & [activateExperiments].
+     * A combination of [registerExperiment] & [startExperiments].
      * @throws ExperimentAlreadyRegistered is the experiment with the same ID already registered
      */
     fun <V> startExperiment(
@@ -113,7 +113,7 @@ interface CadabraConfig {
 
     /**
      * Register & start experiment.
-     * A combination of [registerExperiment] & [activateExperiments].
+     * A combination of [registerExperiment] & [startExperiments].
      * @throws ExperimentAlreadyRegistered is the experiment with the same ID already registered
      */
     fun <V> startExperiment(

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Cadabra.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Cadabra.kt
@@ -1,6 +1,5 @@
 package com.github.fo2rist.cadabra
 
-import com.github.fo2rist.cadabra.exceptions.ExperimentAlreadyRegistered
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotFound
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.github.fo2rist.cadabra.exceptions.UnknownVariant
@@ -69,7 +68,6 @@ interface CadabraConfig {
      * Register experiment.
      * Uses [experiment] enum name as ID.
      * An experiment can only be used after it's registered.
-     * @throws ExperimentAlreadyRegistered is the experiment with the same ID already registered
      */
     fun <V> registerExperiment(
         experiment: KClass<V>
@@ -79,7 +77,6 @@ interface CadabraConfig {
      * Register experiment.
      * Uses [experiment] enum name as ID.
      * An experiment can only be used after it's registered.
-     * @throws ExperimentAlreadyRegistered is the experiment with the same ID already registered
      */
     fun <V> registerExperiment(
         experiment: Class<V>
@@ -104,7 +101,6 @@ interface CadabraConfig {
     /**
      * Register & start experiment.
      * A combination of [registerExperiment] & [startExperiments].
-     * @throws ExperimentAlreadyRegistered is the experiment with the same ID already registered
      */
     fun <V> startExperiment(
         experiment: KClass<V>,
@@ -114,7 +110,6 @@ interface CadabraConfig {
     /**
      * Register & start experiment.
      * A combination of [registerExperiment] & [startExperiments].
-     * @throws ExperimentAlreadyRegistered is the experiment with the same ID already registered
      */
     fun <V> startExperiment(
         experiment: Class<V>,

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Cadabra.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Cadabra.kt
@@ -3,6 +3,7 @@ package com.github.fo2rist.cadabra
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotFound
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.github.fo2rist.cadabra.exceptions.UnknownVariant
+import com.github.fo2rist.cadabra.exceptions.VariantNotFound
 import kotlin.reflect.KClass
 
 /**
@@ -114,5 +115,15 @@ interface CadabraConfig {
     fun <V> startExperiment(
         experiment: Class<V>,
         resolver: Resolver<V>
+    ): CadabraConfig where V : Variant, V : Enum<V>
+
+    /**
+     * Register & start experiment with default variant active.
+     * The first item of variants enum is the default one.
+     * A combination of [registerExperiment] & [startExperiments].
+     * @throws VariantNotFound if provided experiment doesn't have variants
+     */
+    fun <V> startExperiment(
+        experiment: KClass<V>
     ): CadabraConfig where V : Variant, V : Enum<V>
 }

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/CadabraImpl.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/CadabraImpl.kt
@@ -1,8 +1,8 @@
 package com.github.fo2rist.cadabra
 
 import com.github.fo2rist.cadabra.exceptions.ExperimentAlreadyRegistered
-import com.github.fo2rist.cadabra.exceptions.ExperimentNotActive
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotFound
+import com.github.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.github.fo2rist.cadabra.exceptions.UnknownVariant
 import com.github.fo2rist.cadabra.resolvers.StaticResolver
 import kotlin.reflect.KClass
@@ -25,7 +25,7 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
 
         // TODO maybe return just default option, or create registration with default option 06/22/2019
         val result = experimentResolverPair.second?.variant
-            ?: throw ExperimentNotActive("Experiment '$experiment' is not active")
+            ?: throw ExperimentNotStarted("Experiment '$experiment' is not started")
 
         return experiment.cast(result)
     }
@@ -44,7 +44,7 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
         return this
     }
 
-    override fun activateExperiments(config: ExperimentsConfig) {
+    override fun startExperiments(config: ExperimentsConfig) {
         for ((experimentId, variantName) in config.entries) {
             val experiment = resolversMap[experimentId]?.first
                 ?: continue
@@ -56,8 +56,8 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
         }
     }
 
-    override fun activateExperimentsAsync(configProvider: ExperimentsConfigProvider) {
-        configProvider.attach(this::activateExperiments)
+    override fun startExperimentsAsync(configProvider: ExperimentsConfigProvider) {
+        configProvider.attach(this::startExperiments)
     }
 
     override fun <V> startExperiment(
@@ -88,7 +88,7 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
         updateResolver(experiment, resolver)
     }
 
-    //null resolver effectively makes the experiment inactive
+    //null resolver effectively makes the experiment inactive (waiting for start)
     private fun updateResolver(
         experiment: Class<out Variant>,
         resolver: Resolver<out Variant>?

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/CadabraImpl.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/CadabraImpl.kt
@@ -3,6 +3,7 @@ package com.github.fo2rist.cadabra
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotFound
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.github.fo2rist.cadabra.exceptions.UnknownVariant
+import com.github.fo2rist.cadabra.exceptions.VariantNotFound
 import com.github.fo2rist.cadabra.resolvers.StaticResolver
 import kotlin.reflect.KClass
 
@@ -22,7 +23,6 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
         val experimentResolverPair = resolversMap[experiment.experimentId]
             ?: throw ExperimentNotFound("Experiment '$experiment' is not registered")
 
-        // TODO maybe return just default option, or create registration with default option 06/22/2019
         val result = experimentResolverPair.second?.variant
             ?: throw ExperimentNotStarted("Experiment '$experiment' is not started")
 
@@ -72,6 +72,16 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
         resolver: Resolver<V>
     ): CadabraConfig where V : Variant, V : Enum<V> {
         updateResolver(experiment, resolver)
+        return this
+    }
+
+    override fun <V> startExperiment(
+        experiment: KClass<V>
+    ): CadabraConfig where V : Variant, V : Enum<V> {
+        val defaultVariant = experiment.defaultVariant
+            ?: throw VariantNotFound("$experiment class doesn't have enum constants")
+
+        updateResolver(experiment.java, StaticResolver(defaultVariant))
         return this
     }
 

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/CadabraImpl.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/CadabraImpl.kt
@@ -1,6 +1,5 @@
 package com.github.fo2rist.cadabra
 
-import com.github.fo2rist.cadabra.exceptions.ExperimentAlreadyRegistered
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotFound
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.github.fo2rist.cadabra.exceptions.UnknownVariant
@@ -33,14 +32,14 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
     override fun <V> registerExperiment(
         experiment: Class<V>
     ): CadabraConfig where V : Variant, V : Enum<V> {
-        registerNew(experiment, null)
+        updateResolver(experiment, null)
         return this
     }
 
     override fun <V> registerExperiment(
         experiment: KClass<V>
     ): CadabraConfig where V : Variant, V : Enum<V> {
-        registerNew(experiment.java, null)
+        updateResolver(experiment.java, null)
         return this
     }
 
@@ -64,7 +63,7 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
         experiment: KClass<V>,
         resolver: Resolver<V>
     ): CadabraConfig where V : Variant, V : Enum<V> {
-        registerNew(experiment.java, resolver)
+        updateResolver(experiment.java, resolver)
         return this
     }
 
@@ -72,20 +71,8 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
         experiment: Class<V>,
         resolver: Resolver<V>
     ): CadabraConfig where V : Variant, V : Enum<V> {
-        registerNew(experiment, resolver)
-        return this
-    }
-
-    private fun <V> registerNew(
-        experiment: Class<V>,
-        resolver: Resolver<V>?
-    ) where V : Variant {
-        val experimentId = experiment.experimentId
-        if (experimentId in resolversMap) {
-            throw ExperimentAlreadyRegistered("Experiment already registered: $experimentId")
-        }
-
         updateResolver(experiment, resolver)
+        return this
     }
 
     //null resolver effectively makes the experiment inactive (waiting for start)

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/ExperimentsConfigProvider.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/ExperimentsConfigProvider.kt
@@ -3,35 +3,35 @@ package com.github.fo2rist.cadabra
 /**
  * Provider of [ExperimentsConfig] that may configure experiments asynchronously.
  * Can be used if the experiment config not know in advance or takes a lot of time to load.
- * Extend this class and provide instance to [CadabraConfig.activateExperimentsAsync].
+ * Extend this class and provide instance to [CadabraConfig.startExperimentsAsync].
  * Once the config is ready call [provideConfig].
  */
 abstract class ExperimentsConfigProvider {
 
-    // Function that accepts config to activate it.
-    private var activateConfigFun: ((ExperimentsConfig) -> Unit)? = null
+    // Function that accepts config to apply it.
+    private var applyConfigCallback: ((ExperimentsConfig) -> Unit)? = null
 
     /**
      * Tell Cadabra that updated config is available.
      * Can be called multiple times.
      */
     fun provideConfig(config: ExperimentsConfig) {
-        activateConfigFun?.invoke(config)
+        applyConfigCallback?.invoke(config)
     }
 
     /**
      * Override this function to get notified when provider is attached to Cadabra.
      * By default does nothing.
-     * Note that Cadabra may call this method synchronously when [CadabraConfig.activateExperimentsAsync] is called.
+     * Note that Cadabra may call this method synchronously when [CadabraConfig.startExperimentsAsync] is called.
      */
     open fun onAttached() = Unit
 
     /**
      * Register provider at Cadabra.
-     * @param activateConfig function that config provider will call once config is ready.
+     * @param applyConfigCallback function that config provider will call once config is ready.
      */
-    internal fun attach(activateConfig: (ExperimentsConfig) -> Unit) {
-        this.activateConfigFun = activateConfig
+    internal fun attach(applyConfigCallback: (ExperimentsConfig) -> Unit) {
+        this.applyConfigCallback = applyConfigCallback
         this.onAttached()
     }
 }

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Variant.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/Variant.kt
@@ -20,7 +20,6 @@ interface Variant {
     val name: String
 }
 
-
 /**
  * Get ID (simple class name) of the experiment.
  */
@@ -34,8 +33,14 @@ val <V> Class<V>.experimentId: String where V : Variant
     get() = this.simpleName
 
 /**
- *
+ * Find enum item by its [Enum.name].
  */
 internal fun <V : Variant> Class<V>.variantByName(name: String): V? {
     return this.enumConstants.find { it.name == name }
 }
+
+/**
+ * Get first enum item or null if class doesn't have any.
+ */
+internal val <V : Variant> KClass<V>.defaultVariant: V?
+    get() = this.java.enumConstants?.getOrNull(0)

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/exceptions/ExperimentAlreadyRegistered.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/exceptions/ExperimentAlreadyRegistered.kt
@@ -1,6 +1,0 @@
-package com.github.fo2rist.cadabra.exceptions
-
-/**
- * Registration of experiment with duplicating ID attempt.
- */
-class ExperimentAlreadyRegistered(message: String) : IllegalStateException(message)

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/exceptions/ExperimentNotActive.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/exceptions/ExperimentNotActive.kt
@@ -1,8 +1,0 @@
-package com.github.fo2rist.cadabra.exceptions
-
-/**
- * Experiment is registered but not active.
- * @see [com.github.fo2rist.cadabra.CadabraConfig.activateExperiments]
- * @see [com.github.fo2rist.cadabra.CadabraConfig.startExperiment]
- */
-class ExperimentNotActive(message: String) : IllegalStateException(message)

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/exceptions/ExperimentNotStarted.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/exceptions/ExperimentNotStarted.kt
@@ -1,0 +1,8 @@
+package com.github.fo2rist.cadabra.exceptions
+
+/**
+ * Experiment is registered but not started.
+ * @see [com.github.fo2rist.cadabra.CadabraConfig.startExperiment]
+ * @see [com.github.fo2rist.cadabra.CadabraConfig.startExperiments]
+ */
+class ExperimentNotStarted(message: String) : IllegalStateException(message)

--- a/cadabra-core/src/main/java/com/github/fo2rist/cadabra/exceptions/VariantNotFound.kt
+++ b/cadabra-core/src/main/java/com/github/fo2rist/cadabra/exceptions/VariantNotFound.kt
@@ -1,0 +1,6 @@
+package com.github.fo2rist.cadabra.exceptions
+
+/**
+ * Variant was not found.
+ */
+class VariantNotFound(message: String) : Exception(message)

--- a/cadabra-core/src/test/java/com/github/fo2rist/cadabra/CadabraImplKotlinTest.kt
+++ b/cadabra-core/src/test/java/com/github/fo2rist/cadabra/CadabraImplKotlinTest.kt
@@ -1,8 +1,8 @@
 package com.github.fo2rist.cadabra
 
 import com.github.fo2rist.cadabra.exceptions.ExperimentAlreadyRegistered
-import com.github.fo2rist.cadabra.exceptions.ExperimentNotActive
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotFound
+import com.github.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.github.fo2rist.cadabra.exceptions.UnknownVariant
 import com.github.fo2rist.cadabra.resolvers.StaticResolver
 import io.kotlintest.TestCase
@@ -76,10 +76,10 @@ class CadabraImplKotlinTest : WordSpec({
             }
         }
 
-        "throw ExperimentNotActive when experiment registered but not active" {
+        "throw ExperimentNotStarted when experiment registered but not started" {
             cadabra.registerExperiment(SimpleExperiment1::class)
 
-            shouldThrow<ExperimentNotActive> {
+            shouldThrow<ExperimentNotStarted> {
                 cadabra.getExperimentVariant(SimpleExperiment1::class)
             }
         }
@@ -96,37 +96,37 @@ class CadabraImplKotlinTest : WordSpec({
             cadabra.getExperimentVariant(SimpleExperiment1::class.java) shouldBe SimpleExperiment1.A
         }
 
-        "return variant when experiment activated later with activateExperiments" {
+        "return variant when experiment started later with startExperiments" {
             cadabra.registerExperiment(SimpleExperiment1::class)
-            cadabra.activateExperiments(config1A)
+            cadabra.startExperiments(config1A)
 
             cadabra.getExperimentVariant(SimpleExperiment1::class) shouldBe SimpleExperiment1.A
         }
 
-        "return latest activated variant" {
+        "return latest applied variant" {
             cadabra.registerExperiment(SimpleExperiment1::class)
-            cadabra.activateExperiments(config1A)
-            cadabra.activateExperiments(config1B)
+            cadabra.startExperiments(config1A)
+            cadabra.startExperiments(config1B)
 
             cadabra.getExperimentVariant(SimpleExperiment1::class) shouldBe SimpleExperiment1.B
         }
 
-        "return variant when experiment activated later with activateExperimentsAsync" {
+        "return variant when experiment started later with startExperimentsAsync" {
             val configProvider = object : ExperimentsConfigProvider() {}
             cadabra.registerExperiment(SimpleExperiment1::class)
 
-            cadabra.activateExperimentsAsync(configProvider)
+            cadabra.startExperimentsAsync(configProvider)
             configProvider.provideConfig(config1A)
 
             cadabra.getExperimentVariant(SimpleExperiment1::class) shouldBe SimpleExperiment1.A
         }
     }
 
-    "activateExperiments" should {
+    "startExperiments" should {
 
         "ignore unknown experiment IDs" {
             shouldNotThrow<Exception> {
-                cadabra.activateExperiments(ExperimentsConfig.create("DOES_NOT_EXIST" to SimpleExperiment1.A.name))
+                cadabra.startExperiments(ExperimentsConfig.create("DOES_NOT_EXIST" to SimpleExperiment1.A.name))
             }
         }
 
@@ -134,7 +134,7 @@ class CadabraImplKotlinTest : WordSpec({
             cadabra.registerExperiment(SimpleExperiment1::class)
 
             shouldThrow<UnknownVariant> {
-                cadabra.activateExperiments(ExperimentsConfig.create(experiment1Id to "DOES_NOT_EXIST"))
+                cadabra.startExperiments(ExperimentsConfig.create(experiment1Id to "DOES_NOT_EXIST"))
             }
         }
     }

--- a/cadabra-core/src/test/java/com/github/fo2rist/cadabra/CadabraImplKotlinTest.kt
+++ b/cadabra-core/src/test/java/com/github/fo2rist/cadabra/CadabraImplKotlinTest.kt
@@ -1,6 +1,5 @@
 package com.github.fo2rist.cadabra
 
-import com.github.fo2rist.cadabra.exceptions.ExperimentAlreadyRegistered
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotFound
 import com.github.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.github.fo2rist.cadabra.exceptions.UnknownVariant
@@ -28,10 +27,10 @@ class CadabraImplKotlinTest : WordSpec({
 
     "registerExperiment" should {
 
-        "not register experiments with the same ID" {
+        "allow re-registration of experiment with the same ID" {
             cadabra.registerExperiment(SimpleExperiment1::class)
 
-            shouldThrow<ExperimentAlreadyRegistered> {
+            shouldNotThrow<Exception> {
                 cadabra.registerExperiment(SimpleExperiment2::class)
             }
         }
@@ -45,19 +44,11 @@ class CadabraImplKotlinTest : WordSpec({
 
     "startExperiment" should {
 
-        "not start already registered experiment" {
+        "allow starting already registered experiment" {
             cadabra.registerExperiment(SimpleExperiment1::class)
 
-            shouldThrow<ExperimentAlreadyRegistered> {
+            shouldNotThrow<Exception> {
                 cadabra.startExperiment(SimpleExperiment1::class, resolver1A)
-            }
-        }
-
-        "not register experiments with the same ID" {
-            cadabra.startExperiment(SimpleExperiment1::class, resolver1A)
-
-            shouldThrow<ExperimentAlreadyRegistered> {
-                cadabra.startExperiment(SimpleExperiment2::class, resolver2)
             }
         }
 

--- a/cadabra-core/src/test/java/com/github/fo2rist/cadabra/ExperimentsConfigProviderKotlinTest.kt
+++ b/cadabra-core/src/test/java/com/github/fo2rist/cadabra/ExperimentsConfigProviderKotlinTest.kt
@@ -7,13 +7,13 @@ import io.kotlintest.specs.WordSpec
 private val DUMMY_CONFIG = ExperimentsConfig.create()
 
 private lateinit var experimentConfigProvider: ExperimentsConfigProvider
-private var latestActivatedConfig: ExperimentsConfig? = null
+private var latestAppliedConfig: ExperimentsConfig? = null
 private var wasAttached: Boolean = false
 
 class ExperimentsConfigProviderKotlinTest : WordSpec({
 
-    fun registerConfig(config: ExperimentsConfig) {
-        latestActivatedConfig = config
+    fun dummyApplyConfigCallback(config: ExperimentsConfig) {
+        latestAppliedConfig = config
     }
 
     "provideConfig" should {
@@ -21,15 +21,15 @@ class ExperimentsConfigProviderKotlinTest : WordSpec({
         "do nothing if not attached" {
             experimentConfigProvider.provideConfig(DUMMY_CONFIG)
 
-            latestActivatedConfig shouldBe null
+            latestAppliedConfig shouldBe null
         }
 
-        "call activation function after attached" {
-            experimentConfigProvider.attach(::registerConfig)
+        "call apply callback function after attached" {
+            experimentConfigProvider.attach(::dummyApplyConfigCallback)
 
             experimentConfigProvider.provideConfig(DUMMY_CONFIG)
 
-            latestActivatedConfig shouldBe DUMMY_CONFIG
+            latestAppliedConfig shouldBe DUMMY_CONFIG
         }
 
         "call onAttached after attached" {
@@ -40,7 +40,7 @@ class ExperimentsConfigProviderKotlinTest : WordSpec({
     }
 }) {
     override fun beforeTest(testCase: TestCase) {
-        latestActivatedConfig = null
+        latestAppliedConfig = null
         experimentConfigProvider = object : ExperimentsConfigProvider() {
             override fun onAttached() {
                 wasAttached = true

--- a/cadabra-firebase/src/main/java/com/github/fo2rist/cadabra/firebase/FirebaseConfigProvider.kt
+++ b/cadabra-firebase/src/main/java/com/github/fo2rist/cadabra/firebase/FirebaseConfigProvider.kt
@@ -9,7 +9,7 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 const val CADABRA_CONFIG_KEY = "cadabra_experiments"
 
 /**
- * [ExperimentsConfigProvider] that activates experiments automatically by Firebase Remote Config.
+ * [ExperimentsConfigProvider] that starts experiments automatically by Firebase Remote Config.
  * Loads [ExperimentsConfig] as Json from specified remote config field.
  * @see com.github.fo2rist.cadabraandroid.configFromJson
  */
@@ -22,7 +22,7 @@ class FirebaseConfigProvider : ExperimentsConfigProvider {
     /**
      * Create Firebase Config Provider.
      * Be default provider automatically fetches the default config and initiates the remote config loading.
-     * If the automatic fetching is turned off or the remote config was updated [activateExperimentFromRemoteConfig]
+     * If the automatic fetching is turned off or the remote config was updated [startExperimentFromRemoteConfig]
      * triggers re-loading.
      * @param configKey name of key to be fetched from Firebase Remote Config, be default [CADABRA_CONFIG_KEY]
      * @param fetchAutomatically automatically fetch and activate latest Firebase Config once attached to Cadabra
@@ -50,12 +50,12 @@ class FirebaseConfigProvider : ExperimentsConfigProvider {
 
     override fun onAttached() {
         if (this.useDefaults) {
-            activateExperimentFromRemoteConfig()
+            startExperimentFromRemoteConfig()
         }
 
         if (this.fetchAutomatically) {
             firebaseConfig.fetchAndActivate().addOnCompleteListener {
-                activateExperimentFromRemoteConfig()
+                startExperimentFromRemoteConfig()
             }
         }
     }
@@ -63,7 +63,7 @@ class FirebaseConfigProvider : ExperimentsConfigProvider {
     /**
      * Apply current active remote config.
      */
-    fun activateExperimentFromRemoteConfig() {
+    fun startExperimentFromRemoteConfig() {
         val experiments = firebaseConfig.getString(configKey)
         val config = configFromJson(experiments)
         provideConfig(config)

--- a/cadabra-firebase/src/test/java/com/github/fo2rist/cadabra/firebase/FirebaseConfigProviderKotlinTest.kt
+++ b/cadabra-firebase/src/test/java/com/github/fo2rist/cadabra/firebase/FirebaseConfigProviderKotlinTest.kt
@@ -72,7 +72,7 @@ class FirebaseConfigProviderKotlinTest : WordSpec() {
             }
         }
 
-        "activateExperimentFromRemoteConfig" should {
+        "startExperimentFromRemoteConfig" should {
 
             "fetch the current config" {
                 val configProvider = FirebaseConfigProvider(
@@ -84,7 +84,7 @@ class FirebaseConfigProviderKotlinTest : WordSpec() {
 
                 verifyZeroInteractions(firebaseConfigMock)
 
-                configProvider.activateExperimentFromRemoteConfig()
+                configProvider.startExperimentFromRemoteConfig()
 
                 verify(firebaseConfigMock).getString(CONFIG_KEY)
                 verify(firebaseConfigMock, never()).fetchAndActivate()

--- a/sample-android-app/src/main/java/com/github/fo2rist/cadabra/SampleApplication.kt
+++ b/sample-android-app/src/main/java/com/github/fo2rist/cadabra/SampleApplication.kt
@@ -35,10 +35,10 @@ class SampleApplication : Application() {
                 AutoResourceExperiment::class,
                 RandomResolver(AutoResourceExperiment::class)
             )
-            // register experiment without activation
+            // register experiment without starting
             .registerExperiment(FirebaseExperiment::class)
-            // load experiments activation config from Firebase
-            .activateExperimentsAsync(FirebaseConfigProvider())
+            // load experiments config from Firebase
+            .startExperimentsAsync(FirebaseConfigProvider())
     }
 
     @Suppress("MagicNumber")

--- a/sample-android-app/src/main/java/com/github/fo2rist/cadabra/greetingexperiment/FirebaseExperiment.kt
+++ b/sample-android-app/src/main/java/com/github/fo2rist/cadabra/greetingexperiment/FirebaseExperiment.kt
@@ -4,7 +4,7 @@ import com.github.fo2rist.cadabra.Variant
 
 /**
  * Firebase driven Experiment enum without embedded data.
- * Demonstrates async experiment activation with Firebase.
+ * Demonstrates async experiment start with Firebase.
  * Accesses resource the same way [AutoResourceExperiment] does.
  */
 enum class FirebaseExperiment : Variant {


### PR DESCRIPTION
* Remove mention of experiment Activation to simplify the mental model
* Allow experiment to be started after it was already registered
* Allow experiments registration without resolver