### PR TITLE
Return null instead of exception when experiment not found

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ buildscript {
     }
 }
 
+apply {
+    from 'lint.gradle'
+}
+
 allprojects {
     repositories {
         google()

--- a/cadabra-android/build.gradle
+++ b/cadabra-android/build.gradle
@@ -30,6 +30,7 @@ android {
             }
         }
     }
+
 }
 
 dependencies {

--- a/cadabra-android/build.gradle
+++ b/cadabra-android/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion = '28.0.3'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "0.0.1"
 

--- a/cadabra-android/src/main/java/com/fo2rist/cadabra/android/CadabraAndroid.kt
+++ b/cadabra-android/src/main/java/com/fo2rist/cadabra/android/CadabraAndroid.kt
@@ -6,6 +6,7 @@ import com.fo2rist.cadabra.CadabraConfig
 import com.fo2rist.cadabra.Variant
 import com.fo2rist.cadabra.android.CadabraAndroid.Companion.initialize
 import com.fo2rist.cadabra.android.exceptions.NotInitializedException
+import com.fo2rist.cadabra.exceptions.ExperimentNotFound
 import kotlin.reflect.KClass
 
 /**
@@ -20,13 +21,17 @@ interface CadabraAndroid : Cadabra {
 
     /**
      * Get Android resources accessor for active experiment variant.
-     * @throws IllegalStateException if was not initialized via [initialize].
+     * If the experiment is not started the context would behave as normal Android context.
+     * @throws ExperimentNotFound if experiment is not registered
+     * @throws IllegalStateException if Cadabra was not initialized via [initialize].
      */
     fun getExperimentContext(variantClass: KClass<out Variant>): ExperimentContext
 
     /**
      * Get Android resources accessor for active experiment variant.
-     * @throws NotInitializedException if was not initialized via [initialize].
+     * If the experiment is not started the context would behave as normal Android context.
+     * @throws ExperimentNotFound if experiment is not registered
+     * @throws NotInitializedException if Cadabra was not initialized via [initialize].
      */
     fun getExperimentContext(variantClass: Class<out Variant>): ExperimentContext
 

--- a/cadabra-android/src/main/java/com/fo2rist/cadabra/android/ExperimentContext.kt
+++ b/cadabra-android/src/main/java/com/fo2rist/cadabra/android/ExperimentContext.kt
@@ -4,11 +4,12 @@ import com.fo2rist.cadabra.Variant
 
 /**
  * Full context of experiment state as it's resolved for current session/user.
+ * If the experiment wasn't started the [variant] is null resources resolved as is.
  */
 class ExperimentContext(
-    /**
-     * Active variant to be applied by the app.
-     */
-    val variant: Variant,
+    /** Active variant to be applied by the app. */
+    val variant: Variant?,
+
     resources: VariantResources
+
 ) : VariantResources by resources

--- a/cadabra-android/src/main/java/com/fo2rist/cadabra/android/ResourceNamesGenerator.kt
+++ b/cadabra-android/src/main/java/com/fo2rist/cadabra/android/ResourceNamesGenerator.kt
@@ -1,5 +1,7 @@
 package com.fo2rist.cadabra.android
 
+import java.util.Locale
+
 /**
  * Generates names for resources by base resource name and given variant.
  */
@@ -9,7 +11,10 @@ internal class ResourceNamesGenerator {
      * Generate resource name to use by base name current variant.
      * E.g. For "string_a" and variant "A" should give "string_a", for "string_a" and variant "B" should give "string_b"
      */
-    fun generateResourceName(baseResourceName: String, variantName: String): String {
-        return baseResourceName.replaceAfterLast("_", variantName.toLowerCase())
+    fun generateResourceName(baseResourceName: String, variantName: String?): String {
+        return if (variantName == null)
+            baseResourceName
+        else
+            baseResourceName.replaceAfterLast("_", variantName.toLowerCase(Locale.US))
     }
 }

--- a/cadabra-android/src/main/java/com/fo2rist/cadabra/android/ResourcesResolver.kt
+++ b/cadabra-android/src/main/java/com/fo2rist/cadabra/android/ResourcesResolver.kt
@@ -13,11 +13,12 @@ internal class ResourcesResolver(
 
     /**
      * Resolve string by given default string and experiment variant to apply.
+     * @param variantName [com.fo2rist.cadabra.Variant.name] of active variant or null
      * @return string for given variant or [defaultResourceId] if variant-specific option not found.
      * @throws android.content.res.Resources.NotFoundException if default resource doesn't exist.
      */
     @StringRes
-    fun resolveStringResource(context: Context, @StringRes defaultResourceId: Int, variantName: String): Int {
+    fun resolveStringResource(context: Context, @StringRes defaultResourceId: Int, variantName: String?): Int {
         val defaultResourceName = context.stringIdToName(defaultResourceId)
         val resourceName = namesGenerator.generateResourceName(defaultResourceName, variantName)
         return context.stringNameToId(resourceName)
@@ -26,11 +27,12 @@ internal class ResourcesResolver(
 
     /**
      * Resolve layout by given default layout and experiment variant to apply.
+     * @param variantName [com.fo2rist.cadabra.Variant.name] of active variant or null
      * @return string for given variant or [defaultResourceId] if variant-specific option not found.
      * @throws android.content.res.Resources.NotFoundException if default resource doesn't exist.
      */
     @LayoutRes
-    fun resolveLayoutResource(context: Context, @LayoutRes defaultResourceId: Int, variantName: String): Int {
+    fun resolveLayoutResource(context: Context, @LayoutRes defaultResourceId: Int, variantName: String?): Int {
         val defaultResourceName = context.layoutIdToName(defaultResourceId)
         val resourceName = namesGenerator.generateResourceName(defaultResourceName, variantName)
         return context.layoutNameToId(resourceName)

--- a/cadabra-android/src/main/java/com/fo2rist/cadabra/android/VariantResources.kt
+++ b/cadabra-android/src/main/java/com/fo2rist/cadabra/android/VariantResources.kt
@@ -17,6 +17,8 @@ import com.fo2rist.cadabra.Variant
  *
  *  Then if the experiment is resolved to variant B, cadabra will return "title_b" and "layout_b" when
  *  getStringId(R.string.title_a), getLayoutId(R.layout.layout_a) are called.
+ *
+ *  If the experiment wasn't started resolves all resources into defaults.
  */
 interface VariantResources {
     /**
@@ -51,19 +53,19 @@ interface VariantResources {
  */
 internal class VariantResourcesImpl(
     private val context: Context,
-    private val variant: Variant,
+    private val variant: Variant?,
     private val resourcesResolver: ResourcesResolver = defaultResourcesResolver
 ) : VariantResources {
 
     @StringRes
     override fun getStringId(@StringRes defaultResourceId: Int): Int =
-        resourcesResolver.resolveStringResource(context, defaultResourceId, variant.name)
+        resourcesResolver.resolveStringResource(context, defaultResourceId, variant?.name)
 
     override fun getString(@StringRes defaultResourceId: Int): String =
         context.resources.getString(getStringId(defaultResourceId))
 
     override fun getLayoutId(defaultResourceId: Int): Int =
-        resourcesResolver.resolveLayoutResource(context, defaultResourceId, variant.name)
+        resourcesResolver.resolveLayoutResource(context, defaultResourceId, variant?.name)
 
     companion object {
         private val defaultResourcesResolver = ResourcesResolver()

--- a/cadabra-android/src/test/java/com/fo2rist/cadabra/android/CadabraAndroidImplKotlinTest.kt
+++ b/cadabra-android/src/test/java/com/fo2rist/cadabra/android/CadabraAndroidImplKotlinTest.kt
@@ -1,10 +1,16 @@
 package com.fo2rist.cadabra.android
 
-import com.fo2rist.cadabra.android.testdata.SimpleAndroidStaticResolver
+import com.fo2rist.cadabra.Variant
 import com.fo2rist.cadabra.android.testdata.SimpleAndroidExperiment
+import com.fo2rist.cadabra.android.testdata.SimpleAndroidStaticResolver
 import com.fo2rist.cadabra.android.testdata.createAppContextMock
+import com.fo2rist.cadabra.exceptions.ExperimentNotFound
 import io.kotlintest.Spec
+import io.kotlintest.shouldNotBe
+import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
+
+private enum class NotRegisteredExperiment : Variant
 
 class CadabraAndroidImplKotlinTest : WordSpec() {
     private val cadabraAndroidImpl = CadabraAndroidImpl()
@@ -12,11 +18,17 @@ class CadabraAndroidImplKotlinTest : WordSpec() {
     init {
         "CadabraAndroid getExperimentContext" should {
             "return resources object when called for Kotlin class" {
-                cadabraAndroidImpl.getExperimentContext(SimpleAndroidExperiment::class)
+                cadabraAndroidImpl.getExperimentContext(SimpleAndroidExperiment::class) shouldNotBe null
             }
 
             "return resources object when called for Java class" {
-                cadabraAndroidImpl.getExperimentContext(SimpleAndroidExperiment::class.java)
+                cadabraAndroidImpl.getExperimentContext(SimpleAndroidExperiment::class.java) shouldNotBe null
+            }
+
+            "throw ExperimentNotFound when experiment not registered" {
+                shouldThrow<ExperimentNotFound> {
+                    cadabraAndroidImpl.getExperimentContext(NotRegisteredExperiment::class)
+                }
             }
         }
     }

--- a/cadabra-android/src/test/java/com/fo2rist/cadabra/android/CadabraAndroidTest.kt
+++ b/cadabra-android/src/test/java/com/fo2rist/cadabra/android/CadabraAndroidTest.kt
@@ -11,6 +11,7 @@ import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 
 
@@ -19,6 +20,7 @@ import kotlin.test.assertEquals
  * Robolectric serves as the provider of sorta real context, good enough to access resources.
  */
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
 class CadabraAndroidTest {
 
     companion object {

--- a/cadabra-android/src/test/java/com/fo2rist/cadabra/android/ExperimentConfigFactoryTest.kt
+++ b/cadabra-android/src/test/java/com/fo2rist/cadabra/android/ExperimentConfigFactoryTest.kt
@@ -9,8 +9,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
 class ExperimentConfigFactoryTest {
 
     @Test(expected = JSONException::class)

--- a/cadabra-android/src/test/java/com/fo2rist/cadabra/android/ResourceNamesGeneratorKotlinTest.kt
+++ b/cadabra-android/src/test/java/com/fo2rist/cadabra/android/ResourceNamesGeneratorKotlinTest.kt
@@ -12,7 +12,11 @@ class ResourceNamesGeneratorKotlinTest : WordSpec({
             namesGenerator.generateResourceName("string_a", "a") shouldBe "string_a"
         }
 
-        "replace suffix if it doesn't match variant name" {
+        "return the same name if variant name is null" {
+            namesGenerator.generateResourceName("string_a", null) shouldBe "string_a"
+        }
+
+        "replace suffix if it's different from variant name" {
             namesGenerator.generateResourceName("string_a", "b") shouldBe "string_b"
         }
     }

--- a/cadabra-android/src/test/java/com/fo2rist/cadabra/android/ResourcesResolverTest.kt
+++ b/cadabra-android/src/test/java/com/fo2rist/cadabra/android/ResourcesResolverTest.kt
@@ -28,7 +28,7 @@ class ResourcesResolverTest {
     }
 
     @Test
-    fun `resolveStringResource gives string R-string-RESOLVED_NAME for existing name`() {
+    fun `resolveStringResource gives R-string-RESOLVED_NAME for existing name`() {
         mockResolvedResourceName("test_b")
 
         assertEquals(R.string.test_b,
@@ -37,7 +37,7 @@ class ResourcesResolverTest {
     }
 
     @Test
-    fun `resolveStringResource gives string default resource for nonexistent name`() {
+    fun `resolveStringResource gives R-string-DEFAULT resource for nonexistent name`() {
         mockResolvedResourceName("test_nonexistent")
 
         assertEquals(R.string.test_a,
@@ -46,7 +46,7 @@ class ResourcesResolverTest {
     }
 
     @Test
-    fun `resolveLayoutResource gives layout R-layout-RESOLVED_NAME for existing name`() {
+    fun `resolveLayoutResource gives R-layout-RESOLVED_NAME for existing name`() {
         mockResolvedResourceName("test_b")
 
         assertEquals(
@@ -56,7 +56,7 @@ class ResourcesResolverTest {
     }
 
     @Test
-    fun `resolveLayoutResource gives string default resource for nonexistent name`() {
+    fun `resolveLayoutResource gives R-layout-DEFAULT resource for nonexistent name`() {
         mockResolvedResourceName("test_nonexistent")
 
         assertEquals(R.layout.test_a,

--- a/cadabra-android/src/test/java/com/fo2rist/cadabra/android/ResourcesResolverTest.kt
+++ b/cadabra-android/src/test/java/com/fo2rist/cadabra/android/ResourcesResolverTest.kt
@@ -9,9 +9,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
 class ResourcesResolverTest {
     private val context by lazy { RuntimeEnvironment.application }
     private lateinit var namesGeneratorMock: ResourceNamesGenerator

--- a/cadabra-android/src/test/java/com/fo2rist/cadabra/android/VariantResourcesImplKotlinTest.kt
+++ b/cadabra-android/src/test/java/com/fo2rist/cadabra/android/VariantResourcesImplKotlinTest.kt
@@ -44,9 +44,9 @@ class VariantResourcesImplKotlinTest : WordSpec({
         }
 
         "resolve getLayout through resolver's resolveLayoutResource with null" {
-            nullVariantResources.getString(0)
+            nullVariantResources.getLayoutId(0)
 
-            verify(resourcesResolverMock).resolveStringResource(any(), any(), isNull())
+            verify(resourcesResolverMock).resolveLayoutResource(any(), any(), isNull())
         }
     }
 }) {

--- a/cadabra-android/src/test/java/com/fo2rist/cadabra/android/VariantResourcesImplKotlinTest.kt
+++ b/cadabra-android/src/test/java/com/fo2rist/cadabra/android/VariantResourcesImplKotlinTest.kt
@@ -5,6 +5,7 @@ import com.fo2rist.cadabra.android.testdata.createAppContextMock
 import com.fo2rist.cadabra.android.testdata.createResourcesMock
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import io.kotlintest.TestCase
@@ -14,23 +15,53 @@ private val TEST_VARIANT = SimpleAndroidExperiment.B
 
 private lateinit var resourcesResolverMock : ResourcesResolver
 
-private lateinit var variantResources: VariantResources
+private lateinit var normalVariantResources: VariantResources
+private lateinit var nullVariantResources: VariantResources
 
 class VariantResourcesImplKotlinTest : WordSpec({
-    "getString" should {
-        "resolves string" {
-            variantResources.getString(0)
+
+    "resource for experimental variant" should {
+
+        "resolve getString through resolver's resolveStringResource with variant name" {
+            normalVariantResources.getString(0)
 
             verify(resourcesResolverMock).resolveStringResource(any(), any(), eq(TEST_VARIANT.name))
+        }
+
+        "resolve getLayout through resolver's resolveLayoutResource with variant name" {
+            normalVariantResources.getLayoutId(0)
+
+            verify(resourcesResolverMock).resolveLayoutResource(any(), any(), eq(TEST_VARIANT.name))
+        }
+    }
+
+    "resource for null variant" should {
+
+        "resolve getString through resolver's resolveStringResource with null" {
+            nullVariantResources.getString(0)
+
+            verify(resourcesResolverMock).resolveStringResource(any(), any(), isNull())
+        }
+
+        "resolve getLayout through resolver's resolveLayoutResource with null" {
+            nullVariantResources.getString(0)
+
+            verify(resourcesResolverMock).resolveStringResource(any(), any(), isNull())
         }
     }
 }) {
     override fun beforeTest(testCase: TestCase) {
         resourcesResolverMock = mock()
 
-        variantResources = VariantResourcesImpl(
+        normalVariantResources = VariantResourcesImpl(
             createAppContextMock(createResourcesMock()),
             TEST_VARIANT,
             resourcesResolverMock)
+
+        nullVariantResources = VariantResourcesImpl(
+            createAppContextMock(createResourcesMock()),
+            null,
+            resourcesResolverMock
+        )
     }
 }

--- a/cadabra-core/src/main/java/com/fo2rist/cadabra/Cadabra.kt
+++ b/cadabra-core/src/main/java/com/fo2rist/cadabra/Cadabra.kt
@@ -46,6 +46,7 @@ interface Cadabra {
     companion object {
 
         private val _instance = CadabraImpl()
+
         /**
          * Entry point Cadabra experiment variants usage.
          */

--- a/cadabra-core/src/main/java/com/fo2rist/cadabra/Cadabra.kt
+++ b/cadabra-core/src/main/java/com/fo2rist/cadabra/Cadabra.kt
@@ -1,7 +1,6 @@
 package com.fo2rist.cadabra
 
 import com.fo2rist.cadabra.exceptions.ExperimentNotFound
-import com.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.fo2rist.cadabra.exceptions.UnknownVariant
 import com.fo2rist.cadabra.exceptions.VariantNotFound
 import kotlin.reflect.KClass
@@ -30,9 +29,9 @@ interface Cadabra {
      * @see [CadabraConfig.registerExperiment]
      * @see [CadabraConfig.startExperiment]
      * @throws ExperimentNotFound if experiment is not registered
-     * @throws ExperimentNotStarted is experiment was not started
+     * @return null if the experiment was not started
      */
-    fun <V : Variant> getExperimentVariant(experiment: KClass<V>): V
+    fun <V : Variant> getExperimentVariant(experiment: KClass<V>): V?
 
     /**
      * Get experiment variant to apply for this user/session by [Variant] class.
@@ -40,9 +39,9 @@ interface Cadabra {
      * @see [CadabraConfig.registerExperiment]
      * @see [CadabraConfig.startExperiment]
      * @throws ExperimentNotFound if experiment is not registered
-     * @throws ExperimentNotStarted is experiment was not started
+     * @return null if the experiment was not started
      */
-    fun <V : Variant> getExperimentVariant(experiment: Class<V>): V
+    fun <V : Variant> getExperimentVariant(experiment: Class<V>): V?
 
     companion object {
 

--- a/cadabra-core/src/main/java/com/fo2rist/cadabra/CadabraImpl.kt
+++ b/cadabra-core/src/main/java/com/fo2rist/cadabra/CadabraImpl.kt
@@ -1,7 +1,6 @@
 package com.fo2rist.cadabra
 
 import com.fo2rist.cadabra.exceptions.ExperimentNotFound
-import com.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.fo2rist.cadabra.exceptions.UnknownVariant
 import com.fo2rist.cadabra.exceptions.VariantNotFound
 import com.fo2rist.cadabra.resolvers.StaticResolver
@@ -15,16 +14,16 @@ internal class CadabraImpl : Cadabra, CadabraConfig {
 
     private val resolversMap: MutableMap<String, Pair<Class<out Variant>, Resolver<*>?>> = mutableMapOf()
 
-    override fun <V : Variant> getExperimentVariant(experiment: KClass<V>): V {
+    override fun <V : Variant> getExperimentVariant(experiment: KClass<V>): V? {
         return getExperimentVariant(experiment.java)
     }
 
-    override fun <V : Variant> getExperimentVariant(experiment: Class<V>): V {
+    override fun <V : Variant> getExperimentVariant(experiment: Class<V>): V? {
         val experimentResolverPair = resolversMap[experiment.experimentId]
             ?: throw ExperimentNotFound("Experiment '$experiment' is not registered")
 
         val result = experimentResolverPair.second?.variant
-            ?: throw ExperimentNotStarted("Experiment '$experiment' is not started")
+            ?: return null
 
         return experiment.cast(result)
     }

--- a/cadabra-core/src/main/java/com/fo2rist/cadabra/exceptions/ExperimentNotStarted.kt
+++ b/cadabra-core/src/main/java/com/fo2rist/cadabra/exceptions/ExperimentNotStarted.kt
@@ -1,8 +1,0 @@
-package com.fo2rist.cadabra.exceptions
-
-/**
- * Experiment is registered but not started.
- * @see [com.fo2rist.cadabra.CadabraConfig.startExperiment]
- * @see [com.fo2rist.cadabra.CadabraConfig.startExperiments]
- */
-class ExperimentNotStarted(message: String) : IllegalStateException(message)

--- a/cadabra-core/src/test/java/com/fo2rist/cadabra/CadabraImplKotlinTest.kt
+++ b/cadabra-core/src/test/java/com/fo2rist/cadabra/CadabraImplKotlinTest.kt
@@ -1,7 +1,6 @@
 package com.fo2rist.cadabra
 
 import com.fo2rist.cadabra.exceptions.ExperimentNotFound
-import com.fo2rist.cadabra.exceptions.ExperimentNotStarted
 import com.fo2rist.cadabra.exceptions.UnknownVariant
 import com.fo2rist.cadabra.exceptions.VariantNotFound
 import com.fo2rist.cadabra.resolvers.StaticResolver
@@ -62,12 +61,11 @@ class CadabraImplKotlinTest : WordSpec({
             }
         }
 
-        "throw ExperimentNotStarted when experiment registered but not started" {
+        "return null when experiment registered but not started" {
             cadabra.registerExperiment(SimpleExperiment1::class)
 
-            shouldThrow<ExperimentNotStarted> {
-                cadabra.getExperimentVariant(SimpleExperiment1::class)
-            }
+
+            cadabra.getExperimentVariant(SimpleExperiment1::class) shouldBe null
         }
 
         "return given variant when experiment started" {

--- a/cadabra-firebase/build.gradle
+++ b/cadabra-firebase/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion = '28.0.3'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "0.0.1"
 

--- a/default-detekt-config.yml
+++ b/default-detekt-config.yml
@@ -1,81 +1,59 @@
-autoCorrect: false
-failFast: false
-
-# see https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml
-# to find more details about the default configuration file
-
-test-pattern: # Configure exclusions for test sources
-  active: true
-  patterns: # Test file regexps
-    - '.*/test/.*'
-    - '.*/androidTest/.*'
-    - '.*/sharedTest/.*'
-    - '.*TestData.kt'
-    - '.*Test.kt'
-    - '.*Spec.kt'
-    - '.*Spek.kt'
-  exclude-rule-sets:
-    - 'comments'
-  exclude-rules:
-    - 'NamingRules'
-    - 'WildcardImport'
-    - 'MagicNumber'
-    - 'MaxLineLength'
-    - 'LateinitUsage'
-    - 'StringLiteralDuplication'
-    - 'SpreadOperator'
-    - 'TooManyFunctions'
-    - 'TooGenericExceptionCaught'
-
 build:
-  # maxIssues: 0
+  maxIssues: 0
+  excludeCorrectable: false
   weights:
     # complexity: 2
     # LongParameterList: 1
     # style: 1
     # comments: 1
 
+config:
+  validation: true
+  # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+  excludes: ''
+
 processors:
   active: true
   exclude:
+    - 'DetektProgressListener'
   # - 'FunctionCountProcessor'
   # - 'PropertyCountProcessor'
   # - 'ClassCountProcessor'
   # - 'PackageCountProcessor'
   # - 'KtFileCountProcessor'
 
-# console-reports:
-#   active: false
-#   exclude:
-#   #  - 'ProjectStatisticsReport'
-#   #  - 'ComplexityReport'
-#   #  - 'NotificationReport'
-#   #  - 'FindingsReport'
-#   #  - 'BuildFailureReport'
-
-# output-reports:
-#   active: true
-#   exclude:
-#   # - 'PlainOutputReport'
-#   #  - 'HtmlOutputReport'
-#   #  - 'XmlOutputReport'
+console-reports:
+  active: true
+  exclude:
+     - 'ProjectStatisticsReport'
+     - 'ComplexityReport'
+     - 'NotificationReport'
+  #  - 'FindingsReport'
+     - 'FileBasedFindingsReport'
 
 comments:
   active: true
+  excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+  AbsentOrWrongFileLicense:
+    active: false
+    licenseTemplateFile: 'license.template'
   CommentOverPrivateFunction:
     active: false
   CommentOverPrivateProperty:
-    active: true
+    active: false
   EndOfSentenceFormat:
     active: false
-    endOfSentenceFormat: ([.?!][ \t\n\r\f<])|([.?!]$)
+    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
   UndocumentedPublicClass:
-    active: true
-    searchInNestedClass: false
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    searchInNestedClass: true
     searchInInnerClass: true
-    searchInInnerObject: false
-    searchInInnerInterface: false
+    searchInInnerObject: true
+    searchInInnerInterface: true
   UndocumentedPublicFunction:
+    active: false
+  UndocumentedPublicProperty:
     active: false
 
 complexity:
@@ -87,22 +65,30 @@ complexity:
     active: false
     threshold: 10
     includeStaticDeclarations: false
+    includePrivateDeclarations: false
   ComplexMethod:
     active: true
-    threshold: 10
+    threshold: 15
     ignoreSingleWhenExpression: false
+    ignoreSimpleWhenEntries: false
+    ignoreNestingFunctions: false
+    nestingFunctions: [run, let, apply, with, also, use, forEach, isNotNull, ifNull]
   LabeledExpression:
     active: false
+    ignoredLabels: []
   LargeClass:
     active: true
-    threshold: 150
+    threshold: 600
   LongMethod:
     active: true
-    threshold: 20
+    threshold: 50
   LongParameterList:
     active: true
-    threshold: 6
+    functionThreshold: 6
+    constructorThreshold: 7
     ignoreDefaultParameters: false
+    ignoreDataClasses: true
+    ignoreAnnotated: []
   MethodOverloading:
     active: false
     threshold: 6
@@ -111,23 +97,35 @@ complexity:
     threshold: 4
   StringLiteralDuplication:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     threshold: 3
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     thresholdInFiles: 20
     thresholdInClasses: 20
-    thresholdInInterfaces: 20
-    thresholdInObjects: 20
-    thresholdInEnums: 10
+    thresholdInInterfaces: 11
+    thresholdInObjects: 11
+    thresholdInEnums: 11
+    ignoreDeprecated: false
+    ignorePrivate: false
+    ignoreOverridden: false
+
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: false
+  RedundantSuspendModifier:
+    active: false
 
 empty-blocks:
   active: true
   EmptyCatchBlock:
     active: true
-    allowedExceptionNameRegex: "^(ignore|expected).*"
+    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
   EmptyClassBlock:
     active: true
   EmptyDefaultConstructor:
@@ -142,6 +140,7 @@ empty-blocks:
     active: true
   EmptyFunctionBlock:
     active: true
+    ignoreOverridden: false
   EmptyIfBlock:
     active: true
   EmptyInitBlock:
@@ -149,6 +148,8 @@ empty-blocks:
   EmptyKtFile:
     active: true
   EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
     active: true
   EmptyWhenBlock:
     active: true
@@ -159,9 +160,10 @@ exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
     active: false
-    methodNames: 'toString,hashCode,equals,finalize'
+    methodNames: [toString, hashCode, equals, finalize]
   InstanceOfCheckForException:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
   NotImplementedDeclaration:
     active: false
   PrintStackTrace:
@@ -170,19 +172,30 @@ exceptions:
     active: false
   ReturnFromFinally:
     active: false
+    ignoreLabeled: false
   SwallowedException:
     active: false
+    ignoredExceptionTypes:
+     - InterruptedException
+     - NumberFormatException
+     - ParseException
+     - MalformedURLException
+    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
   ThrowingExceptionFromFinally:
     active: false
   ThrowingExceptionInMain:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+    exceptions:
+     - IllegalArgumentException
+     - IllegalStateException
+     - IOException'
   ThrowingNewInstanceOfSameException:
     active: false
   TooGenericExceptionCaught:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     exceptionNames:
      - ArrayIndexOutOfBoundsException
      - Error
@@ -192,6 +205,7 @@ exceptions:
      - IndexOutOfBoundsException
      - RuntimeException
      - Throwable
+    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
@@ -200,96 +214,259 @@ exceptions:
      - Throwable
      - RuntimeException
 
+formatting:
+  active: true
+  android: false
+  autoCorrect: true
+  AnnotationOnSeparateLine:
+    active: false
+    autoCorrect: true
+  ChainWrapping:
+    active: true
+    autoCorrect: true
+  CommentSpacing:
+    active: true
+    autoCorrect: true
+  EnumEntryNameCase:
+    active: false
+    autoCorrect: true
+  Filename:
+    active: true
+  FinalNewline:
+    active: true
+    autoCorrect: true
+    insertFinalNewLine: true
+  ImportOrdering:
+    active: false
+    autoCorrect: true
+  Indentation:
+    active: false
+    autoCorrect: true
+    indentSize: 4
+    continuationIndentSize: 4
+  MaximumLineLength:
+    active: true
+    maxLineLength: 120
+  ModifierOrdering:
+    active: true
+    autoCorrect: true
+  MultiLineIfElse:
+    active: true
+    autoCorrect: true
+  NoBlankLineBeforeRbrace:
+    active: true
+    autoCorrect: true
+  NoConsecutiveBlankLines:
+    active: true
+    autoCorrect: true
+  NoEmptyClassBody:
+    active: true
+    autoCorrect: true
+  NoEmptyFirstLineInMethodBlock:
+    active: false
+    autoCorrect: true
+  NoLineBreakAfterElse:
+    active: true
+    autoCorrect: true
+  NoLineBreakBeforeAssignment:
+    active: true
+    autoCorrect: true
+  NoMultipleSpaces:
+    active: true
+    autoCorrect: true
+  NoSemicolons:
+    active: true
+    autoCorrect: true
+  NoTrailingSpaces:
+    active: true
+    autoCorrect: true
+  NoUnitReturn:
+    active: true
+    autoCorrect: true
+  NoUnusedImports:
+    active: true
+    autoCorrect: true
+  NoWildcardImports:
+    active: true
+  PackageName:
+    active: true
+    autoCorrect: true
+  ParameterListWrapping:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+  SpacingAroundColon:
+    active: true
+    autoCorrect: true
+  SpacingAroundComma:
+    active: true
+    autoCorrect: true
+  SpacingAroundCurly:
+    active: true
+    autoCorrect: true
+  SpacingAroundDot:
+    active: true
+    autoCorrect: true
+  SpacingAroundKeyword:
+    active: true
+    autoCorrect: true
+  SpacingAroundOperators:
+    active: true
+    autoCorrect: true
+  SpacingAroundParens:
+    active: true
+    autoCorrect: true
+  SpacingAroundRangeOperator:
+    active: true
+    autoCorrect: true
+  StringTemplate:
+    active: true
+    autoCorrect: true
+
 naming:
   active: true
   ClassNaming:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  ConstructorParameterNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
   EnumNaming:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: false
-    forbiddenName: ''
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    forbiddenName: []
   FunctionMaxLength:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     maximumFunctionNameLength: 30
   FunctionMinLength:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
+  FunctionParameterNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  InvalidPackageDeclaration:
+    active: false
+    rootPackage: ''
   MatchingDeclarationName:
     active: true
+    mustBeFirst: true
   MemberNameEqualsClassName:
-    active: false
-    ignoreOverriddenFunction: true
+    active: true
+    ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    packagePattern: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'
   TopLevelPropertyNaming:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[a-z][A-Za-z\d]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     maximumVariableNameLength: 64
   VariableMinLength:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     minimumVariableNameLength: 1
   VariableNaming:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
 
 performance:
   active: true
+  ArrayPrimitive:
+    active: true
   ForEachOnRange:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
   SpreadOperator:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
   UnnecessaryTemporaryInstantiation:
     active: true
 
 potential-bugs:
   active: true
+  Deprecation:
+    active: false
   DuplicateCaseInWhenExpression:
     active: true
   EqualsAlwaysReturnsTrueOrFalse:
-    active: false
+    active: true
   EqualsWithHashCodeExist:
     active: true
   ExplicitGarbageCollectionCall:
     active: true
+  HasPlatformType:
+    active: false
+  ImplicitDefaultLocale:
+    active: false
   InvalidRange:
-    active: false
+    active: true
   IteratorHasNextCallsNextMethod:
-    active: false
+    active: true
   IteratorNotThrowingNoSuchElementException:
-    active: false
+    active: true
   LateinitUsage:
     active: false
-    excludeAnnotatedProperties: ""
-    ignoreOnClassesPattern: ""
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    excludeAnnotatedProperties: []
+    ignoreOnClassesPattern: ''
+  MapGetWithNotNullAssertionOperator:
+    active: false
+  MissingWhenCase:
+    active: true
+  RedundantElseInWhen:
+    active: true
   UnconditionalJumpStatementInLoop:
+    active: false
+  UnnecessaryNotNullOperator:
+    active: false
+  UnnecessarySafeCall:
     active: false
   UnreachableCode:
     active: true
   UnsafeCallOnNullableType:
-    active: false
+    active: true
   UnsafeCast:
     active: false
   UselessPostfixExpression:
     active: false
   WrongEqualsTypeParameter:
-    active: false
+    active: true
 
 style:
   active: true
@@ -298,40 +475,70 @@ style:
   DataClassContainsFunctions:
     active: false
     conversionFunctionPrefix: 'to'
+  DataClassShouldBeImmutable:
+    active: false
   EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExplicitItLambdaParameter:
     active: false
   ExpressionBodySyntax:
     active: false
+    includeLineWrapping: false
   ForbiddenComment:
     active: true
-    values: 'FIXME:,STOPSHIP:'
+    values: ['TODO:', 'FIXME:', 'STOPSHIP:']
+    allowedPatterns: ''
   ForbiddenImport:
     active: false
-    imports: ''
-  FunctionOnlyReturningConstant:
+    imports: []
+    forbiddenPatterns: ''
+  ForbiddenMethodCall:
     active: false
+    methods: []
+  ForbiddenPublicDataClass:
+    active: false
+    ignorePackages: ['*.internal', '*.internal.*']
+  ForbiddenVoid:
+    active: false
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  FunctionOnlyReturningConstant:
+    active: true
     ignoreOverridableFunction: true
     excludedFunctions: 'describeContents'
+    excludeAnnotatedFunction: ['dagger.Provides']
+  LibraryCodeMustSpecifyReturnType:
+    active: true
   LoopWithTooManyJumpStatements:
-    active: false
+    active: true
     maxJumpCount: 1
   MagicNumber:
     active: true
-    ignoreNumbers: '-1,0,1,2'
-    ignoreHashCodeFunction: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    ignoreNumbers: ['-1', '0', '1', '2']
+    ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false
+    ignoreRanges: false
+  MandatoryBracesIfStatements:
+    active: false
   MaxLineLength:
     active: true
     maxLineLength: 120
-    excludePackageStatements: false
-    excludeImportStatements: false
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
   MayBeConst:
-    active: false
+    active: true
   ModifierOrder:
     active: true
   NestedClassesVisibility:
@@ -346,14 +553,21 @@ style:
     active: false
   OptionalWhenBraces:
     active: false
+  PreferToOverPairSyntax:
+    active: false
   ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
     active: false
   RedundantVisibilityModifierRule:
     active: false
   ReturnCount:
     active: true
     max: 2
-    excludedFunctions: "equals"
+    excludedFunctions: 'equals'
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:
@@ -365,9 +579,19 @@ style:
     max: 2
   TrailingWhitespace:
     active: false
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableDecimalLength: 5
   UnnecessaryAbstractClass:
+    active: true
+    excludeAnnotatedClasses: ['dagger.Module']
+  UnnecessaryAnnotationUseSiteTarget:
+    active: false
+  UnnecessaryApply:
     active: false
   UnnecessaryInheritance:
+    active: true
+  UnnecessaryLet:
     active: false
   UnnecessaryParentheses:
     active: false
@@ -375,13 +599,30 @@ style:
     active: false
   UnusedImports:
     active: false
+  UnusedPrivateClass:
+    active: true
   UnusedPrivateMember:
+    active: false
+    allowedNames: '(_|ignored|expected|serialVersionUID)'
+  UseArrayLiteralsInAnnotations:
+    active: false
+  UseCheckOrError:
     active: false
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: ""
+    excludeAnnotatedClasses: []
+    allowVars: false
+  UseIfInsteadOfWhen:
+    active: false
+  UseRequire:
+    active: false
+  UselessCallOnNotNull:
+    active: true
   UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
     active: false
   WildcardImport:
     active: true
-    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    excludeImports: ['java.util.*', 'kotlinx.android.synthetic.*']

--- a/lint.gradle
+++ b/lint.gradle
@@ -1,0 +1,29 @@
+subprojects {
+    project.afterEvaluate {
+        if (isAndroidAppOrLib(project)) {
+            applyLintOptionsConfig(project, android.lintOptions)
+        } else if (isJavaLibrary(project)) {
+            project.apply plugin: 'com.android.lint'
+
+            applyLintOptionsConfig(project, lintOptions)
+        }
+    }
+}
+
+static boolean isAndroidAppOrLib(project) {
+    return project.getPlugins().hasPlugin('android') ||
+            project.getPlugins().hasPlugin('android-library')
+}
+
+static boolean isJavaLibrary(project) {
+    return project.getPlugins().hasPlugin('java-library')
+}
+
+static def applyLintOptionsConfig(project, lintOptions) {
+    project.configure(lintOptions) {
+        abortOnError false
+        absolutePaths false
+        lintConfig project.rootProject.file('lint.xml')
+        baseline project.rootProject.file("lint-baseline.xml")
+    }
+}

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!--  Ignore issues that report that baseline issues were present  -->
+    <issue id="LintBaseline" severity="ignore" />
+
+    <!-- Don't want to migrate to AndroidX yet -->
+    <issue id="GradleCompatible" severity="ignore"/>
+    <issue id="GradleDependency" severity="ignore"/>
+</lint>

--- a/sample-android-app/build.gradle
+++ b/sample-android-app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion = '28.0.3'
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "0.0.1"
 

--- a/sample-android-app/src/main/java/com/fo2rist/cadabra/MainActivity.kt
+++ b/sample-android-app/src/main/java/com/fo2rist/cadabra/MainActivity.kt
@@ -30,9 +30,10 @@ class MainActivity : AppCompatActivity() {
 
         val firstExperimentVariant = cadabraAndroid.getExperimentVariant(PlainExperiment::class)
         fab1.setOnClickListener {
-            when (firstExperimentVariant.type) {
+            when (firstExperimentVariant?.type) {
                 MessageStyle.TOAST -> showToast(firstExperimentVariant.message)
                 MessageStyle.SNACK -> showSnackbar(firstExperimentVariant.message)
+                else -> showToast("Experiment 'PlainExperiment' wasn't started")
             }
         }
 
@@ -55,6 +56,11 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun showToast(@StringRes message: Int) {
+        Toast.makeText(this, message, Toast.LENGTH_LONG)
+            .show()
+    }
+
+    private fun showToast(message: CharSequence) {
         Toast.makeText(this, message, Toast.LENGTH_LONG)
             .show()
     }


### PR DESCRIPTION
Cadabra getExperimentVariant now return null
Experiemnt context now safely ignores null as the variant